### PR TITLE
Fix handling when resource does not exist

### DIFF
--- a/src/main/scala/com/lightbend/gcsplugin/GCSResource.scala
+++ b/src/main/scala/com/lightbend/gcsplugin/GCSResource.scala
@@ -12,7 +12,10 @@ object GCSResource {
   def create(storage: Storage, bucketName: String, blobName: String): GCSResource = {
     val blobId = BlobId.of(bucketName, blobName.replace("//", "/"))
     val blob = storage.get(blobId)
-    GCSResource(storage, bucketName, blobName, blob.getUpdateTime(), blob.getSize, exists = true)
+    if (blob == null)
+      GCSResource(storage, bucketName, blobName, 0, 0, exists = false)
+    else
+      GCSResource(storage, bucketName, blobName, blob.getUpdateTime(), blob.getSize, exists = true)
   }
   def openStream(storage: Storage, resource: GCSResource): InputStream = {
     val blobId = BlobId.of(resource.bucketName, resource.blobName.replace("//", "/"))


### PR DESCRIPTION
Hi! I’m encountered NPE, this is because `Storage#get` returns null if it passed resource is not found.

```
[error] sbt.librarymanagement.ResolveException: unresolved dependency: com.datastax.cassandra#cassandra-driver-core;3.4.0: Resolution failed several times for MergedDescriptors(dependency: com.datastax.cassandra#cassandra-driver-core;3.4.0 {compile=[comp
ile(*), master(compile)], runtime=[runtime(*)]},dependency: com.datastax.cassandra#cassandra-driver-core;3.4.0 {compile=[compile(*), master(compile)], runtime=[runtime(*)]})::
[error]         Resolution failed several times for dependency: com.datastax.cassandra#cassandra-driver-parent;3.4.0 {}::
[error]         java.lang.NullPointerException at com.lightbend.gcsplugin.GCSResource$.create(GCSResource.scala:15)
[error]         java.lang.NullPointerException at com.lightbend.gcsplugin.GCSResource$.create(GCSResource.scala:15)
[error]         java.lang.NullPointerException at com.lightbend.gcsplugin.GCSResource$.create(GCSResource.scala:15)
[error]         java.lang.NullPointerException at com.lightbend.gcsplugin.GCSResource$.create(GCSResource.scala:15)
[error]         java.lang.NullPointerException at com.lightbend.gcsplugin.GCSResource$.create(GCSResource.scala:15)
```

 And when that happens, there is another problem that SBT gives up on resolving dependencies. Thus, this PR I implemented to set `GCSResource#exists` with `false` if its retrieved `blob` as null.