### PR TITLE
Don't connect to GCS until needed

### DIFF
--- a/src/main/scala/com/lightbend/gcsplugin/GCSRepository.scala
+++ b/src/main/scala/com/lightbend/gcsplugin/GCSRepository.scala
@@ -15,7 +15,7 @@ import org.apache.ivy.plugins.repository._
 
 case class GCSRepository(bucketName: String, publishPolicy: AccessRigths) extends AbstractRepository {
   private val storage: Storage = StorageOptions.getDefaultInstance.getService
-  private val bucket = storage.get(bucketName)
+  private lazy val bucket = storage.get(bucketName)
 
   override def getResource(source: String): GCSResource = {
     GCSResource.create(storage, bucketName, source)


### PR DESCRIPTION
Currently simply defining a `GCSRepository` would cause a GCS request when it's not needed at this point. This can be an issue if the repository is only used for publishing and user that don't need publish right don't have access to the GCS bucket.